### PR TITLE
Add files via upload

### DIFF
--- a/utility/WatchdogAVR.cpp
+++ b/utility/WatchdogAVR.cpp
@@ -8,31 +8,47 @@
 #include <avr/sleep.h>
 #include <avr/wdt.h>
 
+#if ARDUINO >= 100
+  #include "Arduino.h"
+#else
+  #include "WProgram.h"
+#endif
+
 #include "WatchdogAVR.h"
+
+void(* resetFunc) (void) = 0;
 
 // Define watchdog timer interrupt.
 ISR(WDT_vect) {
     // Nothing needs to be done, however interrupt handler must be defined to
     // prevent a reset.
+if (_sleepy != _MAGIC_SLEEPY) {
+   MCUSR = 0;
+   wdt_disable();	
+   resetFunc(); 
+   }	
 }
 
 int WatchdogAVR::enable(int maxPeriodMS) {
     // Pick the closest appropriate watchdog timer value.
-    int actualMS;
-    _setPeriod(maxPeriodMS, _wdto, actualMS);
+	int actualMS;
+    _setPeriod(abs(maxPeriodMS), _wdto, actualMS);
     // Enable the watchdog and return the actual countdown value.
     wdt_enable(_wdto);
+    if (maxPeriodMS<0) WDTCSR |= (1<<WDIE);             // Enable only watchdog interrupts.
     return actualMS;
 }
 
 void WatchdogAVR::reset() {
     // Reset the watchdog.
+	_sleepy=0;
     wdt_reset();
 }
 
 void WatchdogAVR::disable() {
     // Disable the watchdog and clear any saved watchdog timer value.
     wdt_disable();
+	_sleepy=0;
     _wdto = -1;
 }
 
@@ -70,6 +86,7 @@ int WatchdogAVR::sleep(int maxPeriodMS) {
 
     // Set full power-down sleep mode and go to sleep.
     set_sleep_mode(SLEEP_MODE_PWR_DOWN);
+    _sleepy=_MAGIC_SLEEPY; // The only place where it should get this value
     sleep_mode();
 
     // Chip is now asleep!
@@ -77,6 +94,7 @@ int WatchdogAVR::sleep(int maxPeriodMS) {
     // Once awakened by the watchdog execution resumes here.
     // Start by disabling sleep.
     sleep_disable();
+    _sleepy=0;
 
     // Check if user had the watchdog enabled before sleep and re-enable it.
     if(_wdto != -1) wdt_enable(_wdto);
@@ -86,6 +104,7 @@ int WatchdogAVR::sleep(int maxPeriodMS) {
 }
 
 void WatchdogAVR::_setPeriod(int maxMS, int &wdto, int &actualMS) {
+	_sleepy=0;
     // Note the order of these if statements from highest to lowest  is 
     // important so that control flow cascades down to the right value based
     // on its position in the range of discrete timeouts.

--- a/utility/WatchdogAVR.h
+++ b/utility/WatchdogAVR.h
@@ -1,6 +1,18 @@
 #ifndef WATCHDOGAVR_H
 #define WATCHDOGAVR_H
 
+	
+// Allows the WDT ISR to know if it's called from the sleep function or if
+// a reset is to be performed.
+// The 16 bits holds a "magic value" to prevent reset. This is safer than 
+// using a boolean in case the memory gets trashed.
+// This is defined as global to allow access by the ISR
+
+#include <stdint.h>
+
+static uint16_t _sleepy;
+#define _MAGIC_SLEEPY ~0xDEAD
+
 class WatchdogAVR {
 public:
     WatchdogAVR():
@@ -43,5 +55,8 @@ private:
     // timer was enabled.
     int _wdto;
 };
+
+
+
 
 #endif


### PR DESCRIPTION
When resetting with the watchdog on AVR micros, the watchdog remains enabled after the reset, but with a very short 15ms timeout.
With the default bootloader, that creates a situation where the arduino constantly resets itself until physically powered off.
The patch adds the ability to use the ISR to perform a "soft" reset that will disable the watchdog before resetting.
The patch behaves as expected when using the sleep function.

- Changes are in utility/WatchdogAVR.cpp and utility/WatchdogAVR.h

- Since this is a AVR only problem, nothing is changed for other architectures.

To enable the soft reset, use a negative number in the Watchdog.enable function.
Watchdog.enable(4000); // This uses the hard reset but might hang on some boards (depending on the bootloader)
Watchdog.enable(-4000); // This will never hang and uses the soft reset

The BasicUsage.ino example can be modified as shown to prevent endless reset on arduinos with a bootloader that does not disable the watchdog.


